### PR TITLE
Add push() method to gather data that needs to be pushed, not set within the dataLayer

### DIFF
--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -1,6 +1,10 @@
 @if($enabled)
 <script>
-    dataLayer = [{!! $dataLayer->toJson() !!}];
+window.dataLayer = window.dataLayer || [];
+dataLayer = [{!! $dataLayer->toJson() !!}];
+@foreach($pushData as $item)
+dataLayer.push({!! $item->toJson() !!});
+@endforeach
 </script>
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ $id }}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -153,6 +153,7 @@ class GoogleTagManager
     public function clear()
     {
         $this->dataLayer = new DataLayer();
+        $this->pushDataLayer = new \Illuminate\Support\Collection();
     }
 
     /**

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -29,6 +29,11 @@ class GoogleTagManager
     protected $flashDataLayer;
 
     /**
+     * @var \Illuminate\Support\Collection
+     */
+    protected $pushDataLayer;
+
+    /**
      * @param string $id
      */
     public function __construct($id)
@@ -36,6 +41,7 @@ class GoogleTagManager
         $this->id = $id;
         $this->dataLayer = new DataLayer();
         $this->flashDataLayer = new DataLayer();
+        $this->pushDataLayer = new \Illuminate\Support\Collection();
 
         $this->enabled = true;
     }
@@ -89,7 +95,7 @@ class GoogleTagManager
 
     /**
      * Retrieve the data layer.
-     * 
+     *
      * @return \Spatie\GoogleTagManager\DataLayer
      */
     public function getDataLayer()
@@ -99,7 +105,7 @@ class GoogleTagManager
 
     /**
      * Add data to the data layer for the next request.
-     * 
+     *
      * @param array|string $key
      * @param mixed        $value
      */
@@ -110,12 +116,35 @@ class GoogleTagManager
 
     /**
      * Retrieve the data layer's data for the next request.
-     * 
+     *
      * @return array
      */
     public function getFlashData()
     {
         return $this->flashDataLayer->toArray();
+    }
+
+    /**
+     * Add data to be pushed to the data layer.
+     *
+     * @param array|string $key
+     * @param mixed        $value
+     */
+    public function push($key, $value = null)
+    {
+        $pushItem = new DataLayer();
+        $pushItem->set($key, $value);
+        $this->pushDataLayer->push($pushItem);
+    }
+
+    /**
+     * Retrieve the data layer's data for the next request.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getPushData()
+    {
+        return $this->pushDataLayer;
     }
 
     /**
@@ -128,7 +157,7 @@ class GoogleTagManager
 
     /**
      * Utility function to dump an array as json.
-     * 
+     *
      * @param  array $data
      * @return string
      */

--- a/src/ScriptViewCreator.php
+++ b/src/ScriptViewCreator.php
@@ -34,6 +34,7 @@ class ScriptViewCreator
         $view
             ->with('enabled', $this->googleTagManager->isEnabled())
             ->with('id', $this->googleTagManager->id())
-            ->with('dataLayer', $this->googleTagManager->getDataLayer());
+            ->with('dataLayer', $this->googleTagManager->getDataLayer())
+            ->with('pushData', $this->googleTagManager->getPushData());
     }
 }


### PR DESCRIPTION
I just hit a case where I was required to use dataLayer.push() even on initial page render, so I added a pushDataLayer collection that gathers these and emits any that have been collected during view render.  Thought I'd pass it along if you wish to incorporate it.
