### PR TITLE
Install GoogleTagManagerMiddleware after the StartSession middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ Optionally publish the view files. It's **not** recommended to do this unless ne
 $ php artisan vendor:publish --provider="Spatie\GoogleTagManager\GoogleTagManagerServiceProvider" --tag="views"
 ```
 
-If you plan on using the [flash-functionality](#flashing-data-for-the-next-request) you must install the middleware:
+If you plan on using the [flash-functionality](#flashing-data-for-the-next-request) you must install the GoogleTagManagerMiddleware, after the StartSession middleware:
 
 ```php
 // app/Http/Kernel.php
 
     protected $middleware = [
         ...
+        'Illuminate\Session\Middleware\StartSession',
         'Spatie\GoogleTagManager\GoogleTagManagerMiddleware',
         ...
     ];


### PR DESCRIPTION
#### Improve installation instructions on using the flash feature. 

Hopefully this should save other developers a couple of hours of debugging, especially when they upgrade from 5.1. I spend quite a few hours locating this, while doing said upgrade from 5.1 to 5.4. 

With the Laravel 5.2 using the middleware groups, it's easy to error, and re-order the middlewares. Especially when we don't know the order of middleware matters. 

E.g. like when I moved the various middlewares from global to the 'web' middleware, and re-ordered them alphabetically for readability -.- (sigh).