### PR TITLE
Split the script into the script and noscript part.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,18 @@ return [
 
 ### Basic Example
 
-First you'll need to include Google Tag Manager's script. Google's docs recommend doing this right after the body tag.
+First you'll need to include Google Tag Manager's script, and the noscript version. Google's docs recommend adding the script as high as possible in the `<head>` tag and the noscript immediately after the `<body>` tag.
 
 ```
 {{-- layout.blade.php --}}
 <html>
+  <head>
+    @include('googletagmanager::script')
+    {{-- ... --}}
+  </head>
   {{-- ... --}}
   <body>
-    @include('googletagmanager::script')
+    @include('googletagmanager::noscript')
     {{-- ... --}}
   </body>
 </html>

--- a/resources/views/noscript.blade.php
+++ b/resources/views/noscript.blade.php
@@ -1,0 +1,4 @@
+@if($enabled)
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ $id }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+@endif

--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -6,8 +6,6 @@ dataLayer = [{!! $dataLayer->toJson() !!}];
 dataLayer.push({!! $item->toJson() !!});
 @endforeach
 </script>
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ $id }}"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/src/GoogleTagManagerServiceProvider.php
+++ b/src/GoogleTagManagerServiceProvider.php
@@ -26,6 +26,11 @@ class GoogleTagManagerServiceProvider extends ServiceProvider
             ['googletagmanager::script'],
             'Spatie\GoogleTagManager\ScriptViewCreator'
         );
+
+        $this->app['view']->creator(
+            ['googletagmanager::noscript'],
+            'Spatie\GoogleTagManager\ScriptViewCreator'
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes #13 

By providing two separate views, the user can include them at the appropriate part of the document as recommended by Google.

From #13:

> According to GTM docs (https://developers.google.com/tag-manager/quickstart) <script> should be placed "as close to the opening <head> tag as possible" and <noscript> part "immediately after the opening <body> tag".
Simo Ahava explains reasoning behind this: https://www.simoahava.com/gtm-tips/gtm-container-snippet-in-the-head/
