### PR TITLE
noscript dataLayer parameters

### DIFF
--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -6,8 +6,7 @@ dataLayer = [{!! $dataLayer->toJson() !!}];
 dataLayer.push({!! $item->toJson() !!});
 @endforeach
 </script>
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ $id }}"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript><iframe src="//www.googletagmanager.com/ns.html?{!! http_build_query(array_merge($noscriptData, ['id' => $id])) !!}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -148,6 +148,21 @@ class GoogleTagManager
     }
 
     /**
+     * Retrieve the data layer's data and push data in a flat array.dot k=>v array
+     *
+     * @return array
+     */
+    public function getNoscriptData()
+    {
+        $data = $this->dataLayer->toArray();
+        foreach ($this->pushDataLayer as $pushData) {
+            $data = array_merge($data, $pushData);
+        }
+
+        return \Illuminate\Support\Arr::dot($data);
+    }
+
+    /**
      * Clear the data layer.
      */
     public function clear()

--- a/src/ScriptViewCreator.php
+++ b/src/ScriptViewCreator.php
@@ -25,6 +25,7 @@ class ScriptViewCreator
             ->with('enabled', $this->googleTagManager->isEnabled())
             ->with('id', $this->googleTagManager->id())
             ->with('dataLayer', $this->googleTagManager->getDataLayer())
-            ->with('pushData', $this->googleTagManager->getPushData());
+            ->with('pushData', $this->googleTagManager->getPushData())
+            ->with('noscriptData', $this->googleTagManager->getNoscriptData());
     }
 }


### PR DESCRIPTION
With relation to the issue https://github.com/spatie/laravel-googletagmanager/issues/12

This change includes the `$dataLayer` and `$pushData` in the call to the GTM noscript iframe endpoint.