### PR TITLE
Update GTM

### DIFF
--- a/resources/config/config.php
+++ b/resources/config/config.php
@@ -24,4 +24,8 @@ return [
      */
     'sessionKey' => '_googleTagManager',
 
+    /*
+     * Replace default dataLayer with your own variable
+     */
+    'layer' => 'dataLayer',
 ];

--- a/resources/config/config.php
+++ b/resources/config/config.php
@@ -5,8 +5,8 @@ return [
     /*
      * The Google Tag Manager id, should be a code that looks something like "gtm-xxxx".
      */
-    'id' => '',
-    
+    'id' => [''],
+
     /*
      * Enable or disable script rendering. Useful for local development.
      */

--- a/resources/config/config.php
+++ b/resources/config/config.php
@@ -17,7 +17,7 @@ return [
      * in a dedicated file. You can optionally define the path
      * to that file here and we will load it for you.
      */
-    'macroPath' => '',
+    'macroPath' => app_path(''),
 
     /*
      * The key under which data is saved to the session with flash.

--- a/resources/views/noscript.blade.php
+++ b/resources/views/noscript.blade.php
@@ -1,0 +1,5 @@
+@if($enabled)
+@foreach($id as $item)
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $item }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+@endforeach
+@endif

--- a/resources/views/noscript.blade.php
+++ b/resources/views/noscript.blade.php
@@ -1,5 +1,13 @@
 @if($enabled)
+@php
+$dLayer = "";
+
+foreach($noScript as $ns)
+$dLayer += "&" . $ns;
+endforeach
+
+@endphp
 @foreach($id as $item)
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $item }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $item }}{{ $dLayer }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 @endforeach
 @endif

--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -6,8 +6,6 @@ dataLayer = [{!! $dataLayer->toJson() !!}];
 dataLayer.push({!! $item->toJson() !!});
 @endforeach
 </script>
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ $id }}"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -6,9 +6,11 @@ dataLayer = [{!! $dataLayer->toJson() !!}];
 dataLayer.push({!! $item->toJson() !!});
 @endforeach
 </script>
+@foreach($id as $item)
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-})(window,document,'script','dataLayer','{{ $id }}');</script>
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ $item }}');</script>
+@endforeach
 @endif

--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -11,6 +11,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{ $id }}');</script>
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 @endif

--- a/resources/views/script.blade.php
+++ b/resources/views/script.blade.php
@@ -11,6 +11,6 @@ dataLayer.push({!! $item->toJson() !!});
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','{{ $item }}');</script>
+})(window,document,'script','{{ $layer }}','{{ $item }}');</script>
 @endforeach
 @endif

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -9,7 +9,7 @@ class GoogleTagManager
     use Macroable;
 
     /**
-     * @var string
+     * @var string[]
      */
     protected $id;
 
@@ -49,7 +49,7 @@ class GoogleTagManager
     /**
      * Return the Google Tag Manager id.
      *
-     * @return string
+     * @return string[]
      */
     public function id()
     {

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -34,6 +34,11 @@ class GoogleTagManager
     protected $flashDataLayer;
 
     /**
+     * @var \Spatie\GoogleTagManager\DataLayer
+     */
+    protected $noJSDataLayer;
+
+    /**
      * @var \Illuminate\Support\Collection
      */
     protected $pushDataLayer;
@@ -47,6 +52,7 @@ class GoogleTagManager
         $this->layer = $layer;
         $this->dataLayer = new DataLayer();
         $this->flashDataLayer = new DataLayer();
+        $this->noJSDataLayer = new DataLayer();
         $this->pushDataLayer = new \Illuminate\Support\Collection();
 
         $this->enabled = true;
@@ -138,6 +144,27 @@ class GoogleTagManager
     public function getFlashData()
     {
         return $this->flashDataLayer->toArray();
+    }
+
+    /**
+     * Add data to the data layer for the next request.
+     *
+     * @param array|string $key
+     * @param mixed        $value
+     */
+    public function noScript($key, $value = null)
+    {
+        $this->noJSDataLayer->set($key, $value);
+    }
+
+    /**
+     * Retrieve the data layer's data for the next request.
+     *
+     * @return array
+     */
+    public function getNoScriptData()
+    {
+        return $this->noJSDataLayer->toArray();
     }
 
     /**

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -44,7 +44,8 @@ class GoogleTagManager
     protected $pushDataLayer;
 
     /**
-     * @param string $id
+     * @param string[] $id
+     * @param string $layer
      */
     public function __construct($id, $layer)
     {

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -14,6 +14,11 @@ class GoogleTagManager
     protected $id;
 
     /**
+     * @var string
+     */
+    protected $layer;
+
+    /**
      * @var bool
      */
     protected $enabled;
@@ -36,9 +41,10 @@ class GoogleTagManager
     /**
      * @param string $id
      */
-    public function __construct($id)
+    public function __construct($id, $layer)
     {
         $this->id = $id;
+        $this->layer = $layer;
         $this->dataLayer = new DataLayer();
         $this->flashDataLayer = new DataLayer();
         $this->pushDataLayer = new \Illuminate\Support\Collection();
@@ -54,6 +60,16 @@ class GoogleTagManager
     public function id()
     {
         return $this->id;
+    }
+
+    /**
+     * Return the Google Tag Manager id.
+     *
+     * @return string
+     */
+    public function getLayer()
+    {
+        return $this->layer;
     }
 
     /**

--- a/src/GoogleTagManagerServiceProvider.php
+++ b/src/GoogleTagManagerServiceProvider.php
@@ -23,7 +23,7 @@ class GoogleTagManagerServiceProvider extends ServiceProvider
         ], 'views');
 
         $this->app['view']->creator(
-            ['googletagmanager::script'],
+            ['googletagmanager::script', 'googletagmanager::noscript'],
             'Spatie\GoogleTagManager\ScriptViewCreator'
         );
     }

--- a/src/GoogleTagManagerServiceProvider.php
+++ b/src/GoogleTagManagerServiceProvider.php
@@ -35,7 +35,7 @@ class GoogleTagManagerServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../resources/config/config.php', 'googletagmanager');
 
-        $googleTagManager = new GoogleTagManager(config('googletagmanager.id'));
+        $googleTagManager = new GoogleTagManager(config('googletagmanager.id'), config('googletagmanager.layer'));
 
         if (config('googletagmanager.enabled') === false) {
             $googleTagManager->disable();

--- a/src/ScriptViewCreator.php
+++ b/src/ScriptViewCreator.php
@@ -25,6 +25,7 @@ class ScriptViewCreator
             ->with('enabled', $this->googleTagManager->isEnabled())
             ->with('id', $this->googleTagManager->id())
             ->with('dataLayer', $this->googleTagManager->getDataLayer())
-            ->with('pushData', $this->googleTagManager->getPushData());
+            ->with('pushData', $this->googleTagManager->getPushData())
+            ->with('layer', $this->googleTagManager->layer());
     }
 }

--- a/src/ScriptViewCreator.php
+++ b/src/ScriptViewCreator.php
@@ -26,6 +26,7 @@ class ScriptViewCreator
             ->with('id', $this->googleTagManager->id())
             ->with('dataLayer', $this->googleTagManager->getDataLayer())
             ->with('pushData', $this->googleTagManager->getPushData())
+            ->with('noScript', $this->googleTagManager->getNoScriptData())
             ->with('layer', $this->googleTagManager->layer());
     }
 }


### PR DESCRIPTION
+ Split script and noscript
+ Ability to use multiple tracking id
+ Way to rename dataLayer variable
+ Added dataLayer for no script which used when there is no Javascript support

downside:
- Cannot map no script dataLayer with different tracking id, it will send same variable for all tracking id.

expected:
id=GTM-AAAA&key1=val1&key2=val2
id=GTM-BBBB&key3=val3

- Not Tested 👎 