### PR TITLE
Add id setter method to GoogleTagManager class.

### DIFF
--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -57,6 +57,16 @@ class GoogleTagManager
     }
 
     /**
+     * Set the Google Tag Manager id.
+     *
+     * @param string $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
      * Check whether script rendering is enabled.
      *
      * @return bool


### PR DESCRIPTION
For one of our websites with multiple regions, we use various GTM Containers. We therefore need a way to change the `id` on demand form within our Middleware / Controllers. Hopefully this might be helpful for others too.

Thanks for the package :)