### PR TITLE
Add support for environments in Google Tag Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-googletagmanager` will be documented in this file
 
+## Unreleased
+- Add support for Environments (fixes https://github.com/spatie/laravel-googletagmanager/issues/2)
+
 ## 2.5.1 - 2018-10-15
 - Fixed view creator
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ return [
      * Enable or disable script rendering. Useful for local development.
      */
     'enabled' => true,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Google Tags Environments
+    |--------------------------------------------------------------------------
+    |
+    | If you want to use environments in Google Tag Manager you have to enable the
+    | use of environments by defining environmentsEnabled as true and define the
+    | the gtmAuth and gtmPreview keys.
+    |
+    */
+    'environmentsEnabled' => false,
+
+    // The gtm_auth parameter of the Google Tag Manager environment to use
+    'gtmAuth' => '',
+
+    // The gtm_preview parameter of the Google Tag Manager environment to use
+    'gtmPreview' => '',
 
     /*
      * If you want to use some macro's you 'll probably store them
@@ -113,6 +131,20 @@ return [
 ];
 ```
 
+If you want to use environments within Google Tag Manager you have to enable environmentsEnabled and configure the
+gtmAuth and gtmPreview keys, for example:
+
+```php
+return [
+    'id' => 'GTM-XXXXXX',
+    'enabled' => env('APP_ENV') === 'production',
+    'environmentsEnabled' => true,
+    'gtmAuth' => 'XXXXXXXXXXXXXXXXXXXXXX',
+    'gtmPreview' => 'env-X',
+    'macroPath => app_path('Services/GoogleTagManager/Macros.php'),
+];
+``` 
+ 
 ## Usage
 
 ### Basic Example
@@ -208,6 +240,10 @@ $enabled = GoogleTagManager::isEnabled(); // true|false
 // Enable and disable script rendering
 GoogleTagManager::enable();
 GoogleTagManager::disable();
+
+// Enable and disable the use of Environments parameters
+GoogleTagManager::enableEnvironments();
+GoogleTagManager::disableEnvironments();
 
 // Add data to the data layer (automatically renders right before the tag manager script). Setting new values merges them with the previous ones. Set also supports dot notation.
 GoogleTagManager::set(['foo' => 'bar']);

--- a/resources/config/config.php
+++ b/resources/config/config.php
@@ -13,6 +13,24 @@ return [
     'enabled' => true,
 
     /*
+    |--------------------------------------------------------------------------
+    | Google Tags Environments
+    |--------------------------------------------------------------------------
+    |
+    | If you want to use environments in Google Tag Manager you have to enable the
+    | use of environments by defining environmentsEnabled as true and define the
+    | the gtmAuth and gtmPreview keys.
+    |
+    */
+    'environmentsEnabled' => false,
+
+    // The gtm_auth parameter of the Google Tag Manager environment to use
+    'gtmAuth' => '',
+
+    // The gtm_preview parameter of the Google Tag Manager environment to use
+    'gtmPreview' => '',
+
+    /*
      * If you want to use some macro's you 'll probably store them
      * in a dedicated file. You can optionally define the path
      * to that file here and we will load it for you.

--- a/resources/views/body.blade.php
+++ b/resources/views/body.blade.php
@@ -1,4 +1,4 @@
 @if($enabled)
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $id }}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $id }}{!! $environmentParameters !!}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 @endif

--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -9,6 +9,6 @@ dataLayer.push({!! $item->toJson() !!});
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+'https://www.googletagmanager.com/gtm.js?id='+i+dl+'{!! $environmentParameters !!}';f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{ $id }}');</script>
 @endif

--- a/src/Exceptions/EnvironmentParametersNotSetException.php
+++ b/src/Exceptions/EnvironmentParametersNotSetException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\GoogleTagManager\Exceptions;
+
+class EnvironmentParametersNotSetException extends \Exception
+{
+}

--- a/src/GoogleTagManagerServiceProvider.php
+++ b/src/GoogleTagManagerServiceProvider.php
@@ -41,6 +41,13 @@ class GoogleTagManagerServiceProvider extends ServiceProvider
             $googleTagManager->disable();
         }
 
+        if (config('googletagmanager.environmentsEnabled') === true) {
+            $googleTagManager->enableEnvironmentWithParameters(
+                config('googletagmanager.gtmAuth'),
+                config('googletagmanager.gtmPreview')
+            );
+        }
+
         $this->app->instance('Spatie\GoogleTagManager\GoogleTagManager', $googleTagManager);
         $this->app->alias('Spatie\GoogleTagManager\GoogleTagManager', 'googletagmanager');
 

--- a/src/ScriptViewCreator.php
+++ b/src/ScriptViewCreator.php
@@ -25,6 +25,7 @@ class ScriptViewCreator
             ->with('enabled', $this->googleTagManager->isEnabled())
             ->with('id', $this->googleTagManager->id())
             ->with('dataLayer', $this->googleTagManager->getDataLayer())
-            ->with('pushData', $this->googleTagManager->getPushData());
+            ->with('pushData', $this->googleTagManager->getPushData())
+            ->with('environmentParameters', $this->googleTagManager->getEnvironmentParameters());
     }
 }


### PR DESCRIPTION
This pull request fixes #2 with backward compatibility. By default environments are not used.

This pull request doesn't include the gtm_cookies_win parameter, since this parameter is not required to use environments.  With gtm_cookies_win=x you can preview the configuration changes, see https://blog.mortenbock.dk/2016/06/06/what-is-gtm_cookies_win-in-gtm/.

If requested we can easily add support for gtm_cookies_win by introducing an additional config option, like useGtmCookiesWin as a boolean.