### PR TITLE
Make binding a closure

### DIFF
--- a/src/GoogleTagManagerServiceProvider.php
+++ b/src/GoogleTagManagerServiceProvider.php
@@ -35,13 +35,15 @@ class GoogleTagManagerServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../resources/config/config.php', 'googletagmanager');
 
-        $googleTagManager = new GoogleTagManager(config('googletagmanager.id'));
-
-        if (config('googletagmanager.enabled') === false) {
-            $googleTagManager->disable();
-        }
-
-        $this->app->instance('Spatie\GoogleTagManager\GoogleTagManager', $googleTagManager);
+        $this->app->instance('Spatie\GoogleTagManager\GoogleTagManager', function($app) {
+            $googleTagManager = new GoogleTagManager(config('googletagmanager.id'));
+            
+            if (config('googletagmanager.enabled') === false) {
+                $googleTagManager->disable();
+            }
+            
+            return $googleTagManager;
+        });
         $this->app->alias('Spatie\GoogleTagManager\GoogleTagManager', 'googletagmanager');
 
         if (is_file(config('googletagmanager.macroPath'))) {


### PR DESCRIPTION
By registering the binding as a closure then the class is not actually instantiated unless it will be used.

This has (theoretical) performance improvements but more importantly this allows for modifying the config values inside a test using the Config facade.

Question: Do you prefer type hinting of the `$app` and the return?

```php
$this->app->instance('Spatie\GoogleTagManager\GoogleTagManager', function(App $app): GoogleTagManager {
// instead of the current
$this->app->instance('Spatie\GoogleTagManager\GoogleTagManager', function($app) {
```