### PR TITLE
Add a new middleware for adding user id to the datalayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ GoogleTagManager::set('baz.ho', 'doorrrrr');
 // ]
 ```
 
+### User information via middleware
+
+There is an optional `GoogleTagManagerUserIdMiddleware` that can be used to add the users id to the Google Tag Manager Data Layer. This is usefull if need to pass it on to [Google Analytics](https://support.google.com/tagmanager/answer/4565987?hl=en) or other 3rd party applications.
+
 ### Dump
 
 GoogleTagManager also has a `dump()` function to convert arrays to json objects on the fly. This is useful for sending data to the view that you want to use at a later time.

--- a/resources/config/config.php
+++ b/resources/config/config.php
@@ -34,5 +34,5 @@ return [
     /*
      * The key used in the data layer for storing the authenticated model id.
      */
-    'data_layer_user_key' => env('GOOGLE_TAG_MANAGER_DATA_LAYER_USER_KEY', 'uid'), 
+    'data_layer_user_key' => env('GOOGLE_TAG_MANAGER_DATA_LAYER_USER_KEY', 'user_id'), 
 ];

--- a/resources/config/config.php
+++ b/resources/config/config.php
@@ -24,4 +24,15 @@ return [
      */
     'sessionKey' => env('GOOGLE_TAG_MANAGER_SESSION_KEY', '_googleTagManager'),
 
+    /*
+     * The key of the authenticated model that can be passed to the Google Tag Manager
+     * Data Layer using a middleware. Note that this cannot contain personal information
+     * like email or phone number.
+     */
+    'user_model_key' => env('GOOGLE_TAG_MANAGER_USER_MODEL_KEY', 'id'), 
+
+    /*
+     * The key used in the data layer for storing the authenticated model id.
+     */
+    'data_layer_user_key' => env('GOOGLE_TAG_MANAGER_DATA_LAYER_USER_KEY', 'uid'), 
 ];

--- a/src/GoogleTagManagerUserIdMiddleware
+++ b/src/GoogleTagManagerUserIdMiddleware
@@ -1,0 +1,55 @@
+<?php
+
+namespace Spatie\GoogleTagManager;
+
+use Closure;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Session\Store as Session;
+use Spatie\GoogleTagManager\GoogleTagManager;
+
+class GoogleTagManagerUserIdMiddleware
+{
+    /**
+     * @var \Spatie\GoogleTagManager\GoogleTagManager
+     */
+    protected $googleTagManager;
+
+    /**
+     * @var string
+     */
+    protected $userKey;
+
+    /**
+     * @var string
+     */
+    protected $dataLayerKey;
+
+    /**
+     * @param \Spatie\GoogleTagManager\GoogleTagManager $googleTagManager
+     * @param \Illuminate\Session\Store $session
+     */
+    public function __construct(GoogleTagManager $googleTagManager, Session $session, Config $config)
+    {
+        $this->googleTagManager = $googleTagManager;
+        $this->session = $session;
+
+        $this->userKey = $config->get('googletagmanager.user_model_key');
+        $this->dataLayerKey = $config->get('googletagmanager.data_layer_user_key');
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($request->user()) {
+            $this->googleTagManager->set($this->dataLayerKey, $request->user()->{$this->userKey});
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This PR adds an optional middleware `GoogleTagManagerUserIdMiddleware` which can be useful in the situations where it can be relevant to add the signed in users id to the Google Tag Manager Data Layer where it can then be passed further to other tools.

This might be outside the scope of this package, but giving that it is a completely optional middleware and something that a lot of users probably do, then I thought I would go ahead and make a PR. Completely understand if this is outside the scope 👍 