### PR TITLE
👌 IMPROVE: delay push after load event

### DIFF
--- a/resources/views/body.blade.php
+++ b/resources/views/body.blade.php
@@ -1,4 +1,16 @@
 @if($enabled)
+    <script>
+        function gtmPush() {
+            @unless(empty($dataLayer->toArray()))
+            window.dataLayer.push({!! $dataLayer->toJson() !!});
+            @endunless
+            @foreach($pushData as $item)
+            window.dataLayer.push({!! $item->toJson() !!});
+            @endforeach
+        }
+        addEventListener("load", gtmPush);
+    </script>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $id }}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 @endif
+

--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -1,12 +1,6 @@
 @if($enabled)
 <script>
 window.dataLayer = window.dataLayer || [];
-@unless(empty($dataLayer->toArray()))
-window.dataLayer.push({!! $dataLayer->toJson() !!});
-@endunless
-@foreach($pushData as $item)
-window.dataLayer.push({!! $item->toJson() !!});
-@endforeach
 </script>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
This is helpful to handle privacy policies framework choices before GTM data is pushed.