### PR TITLE
Allow setting custom domains for serving gtm.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 Google Tag Manager allows you manage tracking and marketing optimization with AdWords, Google Analytics, et al. without editing your site code. One way of using Google Tag Manager is by sending data through a `dataLayer` variable in javascript after the page load and on custom events. This package makes managing the data layer easy.
 
-For concrete examples of what you want to send throught the data layer, check out Google Tag Manager's [Developer Guide](https://developers.google.com/tag-manager/devguide).
+For concrete examples of what you want to send through the data layer, check out Google Tag Manager's [Developer Guide](https://developers.google.com/tag-manager/devguide).
 
 You'll also need a Google Tag Manager ID, which you can retrieve by [signing up](https://tagmanager.google.com/#/home) and creating an account for your website.
 
@@ -103,7 +103,18 @@ return [
      * to that file here, and we will load it for you.
      */
     'macroPath' => '',
+    
+     /*
+     * The key under which data is saved to the session with flash.
+     */
+    'sessionKey' => '_googleTagManager',
 
+     /*
+     * Configures the Google Tag Manager script domain.
+     * Modify this value only if you're using "Google Tag Manage: Web Container" client
+     * to serve gtm.js for your web container. Else, keep the default value.
+     */
+    'domain' => 'www.googletagmanager.com',
 ];
 
 ```
@@ -117,6 +128,9 @@ return [
     'id' => 'GTM-XXXXXX',
     'enabled' => env('APP_ENV') === 'production',
     'macroPath' => app_path('Services/GoogleTagManager/Macros.php'),
+    'sessionKey' => '_googleTagManager',
+    // Base domain used in your GTM server container
+    'domain' => 'gtm.yourdomain.com',
 ];
 ```
 

--- a/resources/config/config.php
+++ b/resources/config/config.php
@@ -6,7 +6,7 @@ return [
      * The Google Tag Manager id, should be a code that looks something like "gtm-xxxx".
      */
     'id' => env('GOOGLE_TAG_MANAGER_ID', ''),
-    
+
     /*
      * Enable or disable script rendering. Useful for local development.
      */
@@ -24,4 +24,10 @@ return [
      */
     'sessionKey' => env('GOOGLE_TAG_MANAGER_SESSION_KEY', '_googleTagManager'),
 
+    /*
+     * Configures the Google Tag Manager script domain.
+     * Modify this value only if you're using "Google Tag Manage: Web Container" client
+     * to serve gtm.js for your web container. Else, keep the default value.
+     */
+    'domain' => env('GOOGLE_TAG_MANAGER_DOMAIN', 'www.googletagmanager.com'),
 ];

--- a/resources/views/body.blade.php
+++ b/resources/views/body.blade.php
@@ -1,3 +1,12 @@
+<?php
+/**
+ * @var bool $enabled
+ * @var string $id
+ * @var string $domain
+ * @var \Spatie\GoogleTagManager\DataLayer $dataLayer
+ * @var iterable<\Spatie\GoogleTagManager\DataLayer> $pushData
+ */
+?>
 @if($enabled)
     <script>
         function gtmPush() {
@@ -10,7 +19,13 @@
         }
         addEventListener("load", gtmPush);
     </script>
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ $id }}"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript>
+        <iframe
+            src="https://{{ $domain }}/ns.html?id={{ $id }}"
+            height="0"
+            width="0"
+            style="display:none;visibility:hidden"
+        ></iframe>
+    </noscript>
 @endif
 

--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -1,10 +1,18 @@
+<?php
+/**
+ * @var bool $enabled
+ * @var string $id
+ * @var string $domain
+ */
+?>
 @if($enabled)
-<script>
-window.dataLayer = window.dataLayer || [];
-</script>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','{{ $id }}');</script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+    </script>
+    <script>
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
+        var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+        j.async=true;j.src= 'https://{{ $domain }}/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','{{ $id }}');
+    </script>
 @endif

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -20,6 +20,11 @@ class GoogleTagManager
     protected $enabled;
 
     /**
+     * @var string
+     */
+    protected $gtmScriptDomain;
+
+    /**
      * @var \Spatie\GoogleTagManager\DataLayer
      */
     protected $dataLayer;
@@ -36,10 +41,12 @@ class GoogleTagManager
 
     /**
      * @param string $id
+     * @param string $gtmScriptDomain
      */
-    public function __construct($id)
+    public function __construct($id, $gtmScriptDomain)
     {
         $this->id = $id;
+        $this->gtmScriptDomain = $gtmScriptDomain;
         $this->dataLayer = new DataLayer();
         $this->flashDataLayer = new DataLayer();
         $this->pushDataLayer = new Collection();
@@ -62,6 +69,16 @@ class GoogleTagManager
         $this->id = $id;
 
         return $this;
+    }
+
+    /**
+     * Return the Google Tag Manager script domain.
+     *
+     * @return string
+     */
+    public function gtmScriptDomain()
+    {
+        return $this->gtmScriptDomain;
     }
 
     /**

--- a/src/GoogleTagManagerServiceProvider.php
+++ b/src/GoogleTagManagerServiceProvider.php
@@ -36,12 +36,15 @@ class GoogleTagManagerServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../resources/config/config.php', 'googletagmanager');
 
         $this->app->singleton(GoogleTagManager::class, function($app) {
-            $googleTagManager = new GoogleTagManager(config('googletagmanager.id'));
-            
+            $googleTagManager = new GoogleTagManager(
+                config('googletagmanager.id'),
+                config('googletagmanager.domain')
+            );
+
             if (config('googletagmanager.enabled') === false) {
                 $googleTagManager->disable();
             }
-            
+
             return $googleTagManager;
         });
         $this->app->alias(GoogleTagManager::class, 'googletagmanager');

--- a/src/ScriptViewCreator.php
+++ b/src/ScriptViewCreator.php
@@ -24,6 +24,7 @@ class ScriptViewCreator
         $view
             ->with('enabled', $this->googleTagManager->isEnabled())
             ->with('id', $this->googleTagManager->id())
+            ->with('domain', $this->googleTagManager->gtmScriptDomain())
             ->with('dataLayer', $this->googleTagManager->getDataLayer())
             ->with('pushData', $this->googleTagManager->getPushData());
     }


### PR DESCRIPTION
This PR allows setting custom domains to serve gtm.js script, a critical feature of server GTM containers.

![image](https://github.com/spatie/laravel-googletagmanager/assets/6016632/f368676b-84ac-46c4-ac0c-510b374e3ac5)

- Blade templates are updated to allow overriding domain
- GTM code has been updated according to the latest gtm setup snippet
- Blade templates has been reformatted for better readability
- Doc-block comments are added to blade templates to enhance readability
- A new configuration has been added to specify gtm.js domain
- Documentation is updated

Note: I tried to add tests, but it seems like the package has no test framework and no tests, so I left the PR without tests.