### PR TITLE
Set data-layer values before initialization

### DIFF
--- a/resources/views/body.blade.php
+++ b/resources/views/body.blade.php
@@ -10,9 +10,6 @@
 @if($enabled)
     <script>
         function gtmPush() {
-            @unless(empty($dataLayer->toArray()))
-            window.dataLayer.push({!! $dataLayer->toJson() !!});
-            @endunless
             @foreach($pushData as $item)
             window.dataLayer.push({!! $item->toJson() !!});
             @endforeach
@@ -28,4 +25,3 @@
         ></iframe>
     </noscript>
 @endif
-

--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -3,11 +3,16 @@
  * @var bool $enabled
  * @var string $id
  * @var string $domain
+ * @var \Spatie\GoogleTagManager\DataLayer $dataLayer
+ * @var iterable<\Spatie\GoogleTagManager\DataLayer> $pushData
  */
 ?>
 @if($enabled)
     <script>
         window.dataLayer = window.dataLayer || [];
+        @unless(empty($dataLayer->toArray()))
+        window.dataLayer.push({!! $dataLayer->toJson() !!});
+        @endunless
     </script>
     <script>
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});


### PR DESCRIPTION
It's a common practice to set "Initialization - All Pages" as the trigger for GA4, Meta, and a lot of other tags.
![image](https://github.com/spatie/laravel-googletagmanager/assets/6016632/1e8a435f-0430-4fb0-9728-d65b6099077b)

Currently, there's no way to push any information to the Data Layer before the initialization event, so we have to use the "Window Loaded" event to trigger those tags, which is too late.

The reasons that it's considered late for the tags to initiate after window load are:
1. Many custom events are used as triggers to push new events to different platforms. Since the main tag is initialized after those pushed events (like add_to_cart, purchase, etc.), properties set on the main google tag are not picked by the event. For instance, setting the "server_container_url" on GA4 google tag will not affect other events being sent to GA4.
2. The Page View would not we captured if the page fails to fully load.
3. It's no longer possible to set consent values on the Data Layer before loading tags.

This issue was introduced on https://github.com/spatie/laravel-googletagmanager/compare/2.6.6...2.6.7. This PR attempts to allow setting values to the data layer by using the set method before initialization by moving parts of the setup before GTM is loaded.

The result is all the values added to the GTM service using the `set` method would be set before everything else in GTM.
![image](https://github.com/spatie/laravel-googletagmanager/assets/6016632/73cfa4f4-c3b8-4325-82c7-dddebc2dd3e8)

Example usage:
```php
GoogleTagManage::set(['email' => 'john.doe@example.org']);
```

This will set the email address before initialization, so it's available in the page view event.

