### PR TITLE
Flashing push data

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,4 +22,4 @@ jobs:
            composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
 
       -  name: Execute tests
-         run: vendor/bin/phpunit
+         run: vendor/bin/phpunit --no-coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,25 @@
+name: run-tests
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      -  name: Checkout code
+         uses: actions/checkout@v2
+
+      -  name: Setup PHP
+         uses: shivammathur/setup-php@v2
+         with:
+           php-version: 8.2
+           coverage: none
+
+      -  name: Install dependencies
+         run: |
+           composer require "laravel/framework:12.*" --no-interaction --no-update
+           composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
+
+      -  name: Execute tests
+         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,16 @@ on: [ push, pull_request ]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        php: [8.4, 8.3, 8.2]
+        laravel: [12.*, 11.*, 10.*]
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       -  name: Checkout code
@@ -13,12 +22,18 @@ jobs:
       -  name: Setup PHP
          uses: shivammathur/setup-php@v2
          with:
-           php-version: 8.2
+           php-version: ${{ matrix.php }}
+           extensions: fileinfo
            coverage: none
+
+      -  name: Setup problem matchers
+         run: |
+           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       -  name: Install dependencies
          run: |
-           composer require "laravel/framework:12.*" --no-interaction --no-update
+           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
            composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
 
       -  name: Execute tests

--- a/README.md
+++ b/README.md
@@ -217,6 +217,43 @@ After a form submit, the following dataLayer will be parsed on the contact page:
 </html>
 ```
 
+##### Flashing push data
+
+Sometimes you might want to flash data with the same keys that would otherwise overwrite previous values, using push flash can allow this.
+
+```php
+// OAuthController.php
+
+public function callback()
+{
+    // Authenticate user
+    if ($user->wasRecentlyCreated) {
+        GoogleTagManager::flashPush(['event' => 'sign_up', 'method' => 'OAuth');
+    }
+    GoogleTagManager::flashPush(['event' => 'login', 'method' => 'OAuth');
+
+    return redirect()->intended();
+}
+```
+
+After the redirect, the following pushes will be added to the page:
+
+```html
+<html>
+  <!-- ... -->
+  <body>
+    <script>
+      function gtmPush() {
+        window.dataLayer.push({"event":"sign_up","method":"OAuth"});
+        window.dataLayer.push({"event":"login","method":"OAuth"});
+      }
+      addEventListener("load", gtmPush);
+    </script>
+  <!-- ... -->
+  </body>
+</html>
+```
+
 ### Other Simple Methods
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,23 @@
         }
     ],
     "require": {
-        "php" : ">=5.4.0"
+        "php": ">=5.5",
+        "illuminate/config": "5.1 - 12",
+        "illuminate/http": "5.1 - 12",
+        "illuminate/session": "5.1 - 12",
+        "illuminate/view": "5.1 - 12"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {
             "Spatie\\GoogleTagManager\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Spatie\\GoogleTagManager\\Tests\\": "tests"
         }
     },
     "extra": {
@@ -37,5 +49,9 @@
                 "GoogleTagManager": "Spatie\\GoogleTagManager\\GoogleTagManagerFacade"
             }
         }
+    },
+    "config": {
+        "lock": false,
+        "sort-packages": true
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Spatie Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+</phpunit>

--- a/src/GoogleTagManager.php
+++ b/src/GoogleTagManager.php
@@ -40,6 +40,11 @@ class GoogleTagManager
     protected $pushDataLayer;
 
     /**
+     * @var \Illuminate\Support\Collection
+     */
+    protected $flashPushDataLayer;
+
+    /**
      * @param string $id
      * @param string $gtmScriptDomain
      */
@@ -50,6 +55,7 @@ class GoogleTagManager
         $this->dataLayer = new DataLayer();
         $this->flashDataLayer = new DataLayer();
         $this->pushDataLayer = new Collection();
+        $this->flashPushDataLayer = new Collection();
 
         $this->enabled = true;
     }
@@ -170,6 +176,29 @@ class GoogleTagManager
     public function getPushData()
     {
         return $this->pushDataLayer;
+    }
+
+    /**
+     * Add data to be pushed to the data layer for the next request.
+     *
+     * @param array|string $key
+     * @param mixed        $value
+     */
+    public function flashPush($key, $value = null)
+    {
+        $pushItem = new DataLayer();
+        $pushItem->set($key, $value);
+        $this->flashPushDataLayer->push($pushItem);
+    }
+
+    /**
+     * Retrieve the push data for the next request.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getFlashPushData()
+    {
+        return $this->flashPushDataLayer;
     }
 
     /**

--- a/tests/DataLayerTest.php
+++ b/tests/DataLayerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Spatie\GoogleTagManager\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Spatie\GoogleTagManager\DataLayer;
+use Spatie\GoogleTagManager\GoogleTagManager;
+
+#[CoversClass(DataLayer::class)]
+class DataLayerTest extends TestCase
+{
+    private GoogleTagManager $tagManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tagManager = new GoogleTagManager('', '');
+    }
+
+    #[Test]
+    public function it_sets_from_key_and_value()
+    {
+        $dataLayer = new DataLayer();
+
+        $dataLayer->set('key', 'value');
+
+        self::assertEquals(['key' => 'value'], $dataLayer->toArray());
+    }
+
+    #[Test]
+    public function it_sets_from_an_array()
+    {
+        $dataLayer = new DataLayer();
+
+        $dataLayer->set(['key' => 'value']);
+
+        self::assertEquals(['key' => 'value'], $dataLayer->toArray());
+    }
+
+    #[Test]
+    public function it_clears()
+    {
+        $dataLayer = new DataLayer(['key' => 'value']);
+
+        $dataLayer->clear();
+
+        self::assertEmpty($dataLayer->toArray());
+    }
+
+    #[Test]
+    public function it_encodes_data_to_json()
+    {
+        $dataLayer = new DataLayer(['key' => 'value']);
+
+        $json = $dataLayer->toJson();
+
+        self::assertEquals('{"key":"value"}', $json);
+    }
+}

--- a/tests/GoogleTagManagerMiddlewareTest.php
+++ b/tests/GoogleTagManagerMiddlewareTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Spatie\GoogleTagManager\Tests;
+
+use Illuminate\Config\Repository as Cache;
+use Illuminate\Http\Request;
+use Illuminate\Session\Store as Session;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Spatie\GoogleTagManager\GoogleTagManager;
+use Spatie\GoogleTagManager\GoogleTagManagerMiddleware;
+
+#[CoversClass(GoogleTagManagerMiddleware::class)]
+#[UsesClass(GoogleTagManager::class)]
+class GoogleTagManagerMiddlewareTest extends TestCase
+{
+    /** @var Session&\PHPUnit\Framework\MockObject\MockObject */
+    private $session;
+
+    /** @var Cache&\PHPUnit\Framework\MockObject\MockObject */
+    private $cache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->session = $this->createMock(Session::class);
+        $this->cache = $this->createMock(Cache::class);
+
+        $this->cache->method('get')->willReturn('key');
+    }
+
+    #[Test]
+    public function it_sets_flashed_data_to_the_data_layer()
+    {
+        $tagManager = new GoogleTagManager('', '');
+        $middleware = new GoogleTagManagerMiddleware($tagManager, $this->session, $this->cache);
+
+        $this->session->method('has')->willReturn(true);
+        $this->session->method('get')->willReturn(['key' => 'value']);
+
+        $middleware->handle(new Request(), function () {});
+
+        self::assertEquals([
+            'key' => 'value',
+        ], $tagManager->getDataLayer()->toArray());
+    }
+
+    #[Test]
+    public function it_pushes_flashed_pushes_to_the_push_data_layer()
+    {
+        $tagManager = new GoogleTagManager('', '');
+        $middleware = new GoogleTagManagerMiddleware($tagManager, $this->session, $this->cache);
+
+        $this->session->method('has')->willReturnOnConsecutiveCalls(false, true);
+        $this->session->method('get')->willReturn([['key' => 'value']]);
+
+        $middleware->handle(new Request(), function () {});
+
+        self::assertCount(1, $tagManager->getPushData());
+        self::assertEquals([
+            'key' => 'value',
+        ], $tagManager->getPushData()->first()->toArray());
+    }
+
+    #[Test]
+    public function it_flashes_the_flash_data_to_the_session()
+    {
+        $tagManager = new GoogleTagManager('', '');
+        $middleware = new GoogleTagManagerMiddleware($tagManager, $this->session, $this->cache);
+
+        $tagManager->flash('key', 'value');
+
+        $this->session->expects($this->exactly(2))
+            ->method('flash')
+            ->with(
+                self::callback(static function ($value) {
+                    static $i = 0;
+
+                    return (match (++$i) {
+                        1 => self::equalTo('key'),
+                        2 => self::stringEndsWith(':push'),
+                    })->evaluate($value, returnResult: true);
+                }),
+            );
+
+        $middleware->handle(new Request(), function () {});
+    }
+
+    #[Test]
+    public function it_flashes_the_flash_push_data_to_the_session()
+    {
+        $tagManager = new GoogleTagManager('', '');
+        $middleware = new GoogleTagManagerMiddleware($tagManager, $this->session, $this->cache);
+
+        $tagManager->flashPush('key', 'value');
+
+        $this->session->expects($this->exactly(2))
+            ->method('flash')
+            ->with(
+                self::callback(static function ($value) {
+                    static $i = 0;
+
+                    return (match (++$i) {
+                        1 => self::anything(),
+                        2 => self::stringEndsWith(':push'),
+                    })->evaluate($value, returnResult: true);
+                }),
+                self::callback(static function ($value) {
+                    static $i = 0;
+
+                    return (match (++$i) {
+                        1 => self::anything(),
+                        2 => self::equalTo([['key' => 'value']]),
+                    })->evaluate($value, returnResult: true);
+                }),
+            );
+
+        $middleware->handle(new Request(), function () {});
+    }
+}

--- a/tests/GoogleTagManagerTest.php
+++ b/tests/GoogleTagManagerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Spatie\GoogleTagManager\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Spatie\GoogleTagManager\DataLayer;
+use Spatie\GoogleTagManager\GoogleTagManager;
+
+#[CoversClass(GoogleTagManager::class)]
+class GoogleTagManagerTest extends TestCase
+{
+    private GoogleTagManager $tagManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tagManager = new GoogleTagManager('', '');
+    }
+
+    #[Test]
+    public function it_sets_keys_and_values_to_the_data_layer()
+    {
+        $this->tagManager->set('key', 'value');
+
+        self::assertEquals(['key' => 'value'], $this->tagManager->getDataLayer()->toArray());
+    }
+
+    #[Test]
+    public function it_sets_arrays_to_the_data_layer()
+    {
+        $this->tagManager->set(['key' => 'value']);
+
+        self::assertEquals(['key' => 'value'], $this->tagManager->getDataLayer()->toArray());
+    }
+
+    #[Test]
+    public function it_sets_keys_and_values_to_the_flash_data_layer()
+    {
+        $this->tagManager->flash('key', 'value');
+
+        self::assertEquals(['key' => 'value'], $this->tagManager->getFlashData());
+    }
+
+    #[Test]
+    public function it_sets_arrays_to_the_flash_data_layer()
+    {
+        $this->tagManager->flash(['key' => 'value']);
+
+        self::assertEquals(['key' => 'value'], $this->tagManager->getFlashData());
+    }
+
+    #[Test]
+    public function it_sets_keys_and_values_to_the_push_data_layer()
+    {
+        $this->tagManager->push('key', 'value');
+
+        self::assertEquals(collect([new DataLayer(['key' => 'value'])]), $this->tagManager->getPushData());
+    }
+
+    #[Test]
+    public function it_sets_arrays_to_the_push_data_layer()
+    {
+        $this->tagManager->push(['key' => 'value']);
+
+        self::assertEquals(collect([new DataLayer(['key' => 'value'])]), $this->tagManager->getPushData());
+    }
+
+    #[Test]
+    public function it_sets_keys_and_values_to_the_flas_push_data_layer()
+    {
+        $this->tagManager->flashPush('key', 'value');
+
+        self::assertEquals(collect([new DataLayer(['key' => 'value'])]), $this->tagManager->getFlashPushData());
+    }
+
+    #[Test]
+    public function it_sets_arrays_to_the_flas_push_data_layer()
+    {
+        $this->tagManager->flashPush(['key' => 'value']);
+
+        self::assertEquals(collect([new DataLayer(['key' => 'value'])]), $this->tagManager->getFlashPushData());
+    }
+}


### PR DESCRIPTION
I want to be able to flash multiple events at once, but using `GoogleTagManager::flash()` will merge values with the matching keys into a single object.

This PR introduces the `GoogleTagManager::flashPush()` method that will allow pushing data that will be flashed across requests.