### PR TITLE
Add support for Laravel Octane by using the "scoped" method if it exists

### DIFF
--- a/src/GoogleTagManagerServiceProvider.php
+++ b/src/GoogleTagManagerServiceProvider.php
@@ -35,22 +35,34 @@ class GoogleTagManagerServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../resources/config/config.php', 'googletagmanager');
 
-        $this->app->singleton(GoogleTagManager::class, function($app) {
-            $googleTagManager = new GoogleTagManager(
-                config('googletagmanager.id'),
-                config('googletagmanager.domain')
-            );
+        if (method_exists($this->app, 'scoped')) {
+            $this->app->scoped(GoogleTagManager::class, function($app) {
+                return $this->createGoogleTagManagerInstance($app);
+            });
+        } else {
+            $this->app->singleton(GoogleTagManager::class, function($app) {
+                return $this->createGoogleTagManagerInstance($app);
+            });
+        }
 
-            if (config('googletagmanager.enabled') === false) {
-                $googleTagManager->disable();
-            }
-
-            return $googleTagManager;
-        });
         $this->app->alias(GoogleTagManager::class, 'googletagmanager');
 
         if (is_file(config('googletagmanager.macroPath'))) {
             include config('googletagmanager.macroPath');
         }
+    }
+
+    private function createGoogleTagManagerInstance($app)
+    {
+        $googleTagManager = new GoogleTagManager(
+            config('googletagmanager.id'),
+            config('googletagmanager.domain')
+        );
+
+        if (config('googletagmanager.enabled') === false) {
+            $googleTagManager->disable();
+        }
+
+        return $googleTagManager;
     }
 }


### PR DESCRIPTION
Fixes #41 

The GoogleTagManager class is registered as singleton, which leaks state between Octane requests. For example the `$this->dataLayer` property.

@freekmurze 